### PR TITLE
Adiciona lib cross-env para comando multiplataforma, e busca de posts na api da riot

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
     "react-scripts": "3.2.0"
   },
   "scripts": {
-    "start": "HOST=0.0.0.0 react-scripts start",
+    "start": "cross-env HOST=0.0.0.0 react-scripts start",
     "server": "cd ../server && nodemon ./src/server.js",
     "dev": "run-p server start",
     "build": "react-scripts build",
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.0",
     "eslint": "^6.5.1",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.5.0",

--- a/client/src/components/atoms/Typography/index.jsx
+++ b/client/src/components/atoms/Typography/index.jsx
@@ -2,7 +2,22 @@ import React from "react";
 import PropTypes from "prop-types";
 
 const Typography = props => {
-  const { component, variant, children, className } = props;
+  const { component, variant, children, className, link } = props;
+  
+  if (link) {
+    const Link = component;
+
+    return (
+      <Link 
+        target="_blank" 
+        rel="noopener noreferrer" 
+        href={link} 
+        className={`typography typography__${variant} ${className}`}>
+        {children}
+      </Link>
+    );
+  }
+  
   const Text = component;
 
   return (

--- a/client/src/components/molecules/BalanceChangesOverview/index.jsx
+++ b/client/src/components/molecules/BalanceChangesOverview/index.jsx
@@ -19,8 +19,8 @@ const BCOverview = () => {
   // eslint-disable-next-line no-unused-vars
   const [champions, setChampions] = useState(championsHC);
   const renderIcons = () => {
-    const icons = champions.map(champion => {
-      return <ChampionIcon name={champion} />;
+    const icons = champions.map((champion, index) => {
+      return <ChampionIcon key={index} name={champion} />;
     });
 
     return icons;

--- a/client/src/components/molecules/PostClassic/_post-classic.scss
+++ b/client/src/components/molecules/PostClassic/_post-classic.scss
@@ -17,6 +17,7 @@
     display: inline-block;
     padding: 1.6rem;
     max-width: 70%;
+    min-width: 50%;
 
     position: absolute;
     bottom: 0;
@@ -50,6 +51,10 @@
     }
 
     &:hover > p {
+      color: $color-gold-dark;
+      border-bottom: 2px solid $color-gold-dark;
+    }
+    &:hover > a {
       color: $color-gold-dark;
       border-bottom: 2px solid $color-gold-dark;
     }

--- a/client/src/components/molecules/PostClassic/index.jsx
+++ b/client/src/components/molecules/PostClassic/index.jsx
@@ -22,14 +22,14 @@ const PostClassic = props => {
           {post.title}
         </Typography>
         <Typography component="p" variant="sub">
-          Patch: 10.2 PBE - Postado por Dantenor Francisco
+          {post.tag} - Postado por {post.author}
         </Typography>
         <Typography component="p" variant="p" className="post-classic__desc">
           {post.description}
         </Typography>
         <div className="post-classic__link-container">
-          <Typography component="p" variant="p" className="post-classic__link">
-            Leia mais
+          <Typography link={post.link} component="a" variant="a" className="post-classic__link">
+              Leia mais
           </Typography>
           <MdKeyboardArrowRight className="post-classic__link--arrow" />
         </div>
@@ -45,7 +45,6 @@ PostClassic.propTypes = {
     title: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     image: PropTypes.string.isRequired,
-    commentsCount: PropTypes.number.isRequired
   }).isRequired,
   // Classes extras para o component
   className: PropTypes.string

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2855,12 +2855,12 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-env@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-6.0.3.tgz#4256b71e49b3a40637a0ce70768a6ef5c72ae941"
-  integrity sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==
+cross-env@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.0.tgz#5a3b2ddce51ec713ea58f2fb79ce22e65b4f5479"
+  integrity sha512-rV6M9ldNgmwP7bx5u6rZsTbYidzwvrwIYZnT08hSGLcQCcggofgFW+sNe7IhA1SRauPS0QuLbbX+wdNtpqE5CQ==
   dependencies:
-    cross-spawn "^7.0.0"
+    cross-spawn "^7.0.1"
 
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -2881,7 +2881,7 @@ cross-spawn@^3.0.0:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
   integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==

--- a/server/nodemon.json
+++ b/server/nodemon.json
@@ -1,7 +1,7 @@
 {
   "watch": ["src"],
   "execMap": {
-    "js": "sucrase-node src/server.js"
+    "js": "node -r sucrase/register"
   },
   "ext": "js"
 }

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
     "build": "sucrase ./src -d ./dist --transforms imports"
   },
   "dependencies": {
+    "axios": "^0.19.2",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1"

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,4 +1,4 @@
-require("dotenv").config();
+import 'dotenv/config';
 
 import express from "express";
 import cors from "cors";

--- a/server/src/app/controllers/PostController.js
+++ b/server/src/app/controllers/PostController.js
@@ -1,82 +1,25 @@
-class BankController {
-  // As funções estão async para utilização do mongoose em async/await
+import RiotApi from '../../services/api/riot';
+
+class PostController {
+
   async index(req, res) {
-    const posts = [
+    const response = await RiotApi.page('news').get();
+
+    const { result: { pageContext: { data: { sections } } } }  = response.data;
+
+    const filter = sections.filter(section => section.type === 'news_latest')[0].props.articles;
+
+    const posts = filter.map(post => (
       {
-        title: "Pergunte a riot: Skin decente pro Ivern",
-        description: `Dolore ea velit fugiat et. In irure deserunt qui irure id minim voluptate adipisicing. Eiusmod  nulla sunt nulla consectetur commodo aute deserunt voluptate irure ex sit id tempor.`,
-        image:
-          "https://nexus.leagueoflegends.com/wp-content/uploads/2019/08/Banner_Image_Ask_Riot_zp7rnwkbgfttb0v5frin.jpg",
-        commentsCount: 345,
-        category: "riot"
-      },
-      {
-        title: "TFT: A Ascensão dos elementos",
-        description: `A fase beta de Teamfight Tactics chegou ao fim, e os 
-      elementos ascenderão na segunda temporada! Sendo nosso primeiro novo 
-      conjunto.`,
-        image:
-          "https://nexus.leagueoflegends.com/wp-content/uploads/2019/10/LOL_CMS_314_Tile_01-Feature_H40-V50-min_94ucpce02v5cgf3ootvq.jpg",
-        commentsCount: 24,
-        category: "artigo"
-      },
-      {
-        title: "Atualização do PBE: 25/10",
-        description: `Lorem tempor cillum enim aliqua nulla do pariatur. ipsum officia esse ipsum minim eiusmod adipisicing voluptate. Ullamco consectetur velit qui adipisicing quis dolore culpa anim.`,
-        image:
-          "https://nexus.leagueoflegends.com/wp-content/uploads/2019/12/HQ_Header_Ask_Riot_Preseaosn_f8i1ljevnti7wpo7oh2n.png",
-        commentsCount: 12,
-        category: "pbe"
-      },
-      {
-        title: "TFT: Muda rápido demais. Tenho que trabalhar Riot :(",
-        description: `In exercitation nulla qui veniam elit cillum mollit culpa incididunt ex in in fugiat. Velit adipisicing qui consectetur.`,
-        image:
-          "https://nexus.leagueoflegends.com/wp-content/uploads/2020/01/01_Grappler_exploration02_634b1r0lsgejjohqbnpf.jpg",
-        commentsCount: 24,
-        category: "artigo"
-      },
-      {
-        title: "Dolor id mollit elit nisi tempor mollit aute.",
-        description: `Laborum amet reprehenderit fugiat ut sint. Sint voluptate sint laboris aute veniam consequat. Dolor veniam in aliqua aliquip dolor reprehenderit. Excepteur et adipisicing enim laborum.`,
-        image:
-          "https://nexus.leagueoflegends.com/wp-content/uploads/2020/01/Banner_Ask_Riot_Prestige_Skins_u2g26y3xzliu8ql9bfoi.jpg",
-        commentsCount: 12,
-        category: "artigo"
-      },
-      {
-        title: "Laboris quis consequat excepteur officia.",
-        description: `Ad esse qui sint quis ut ullamco aute culpa anim magna. Tempor do cupidatat eiusmod officia nisi. Dolore est nostrud enim sint excepteur nisi mollit sint amet. In et ea et est eu dolor tempor.`,
-        image:
-          "https://nexus.leagueoflegends.com/wp-content/uploads/2020/01/01_Banner_Fiddlesticks_Concept_9j7dhjnqxbpc7o0qibqp.jpg",
-        commentsCount: 345,
-        category: "pbe"
-      },
-      {
-        title: "Commodo eu laboris consequat aliqua.",
-        description: `Culpa eu occaecat laboris elit eiusmod ex sunt eiusmod deserunt commodo Lorem duis dolor. Dolore minim velit aliqua ex veniam officia anim ullamco esse.`,
-        image:
-          "https://nexus.leagueoflegends.com/wp-content/uploads/2019/12/02_Forge_Concept1_l97uywotlnqob8xrr0w7.png",
-        commentsCount: 24,
-        category: "artigo"
-      },
-      {
-        title: "Do laborum id reprehenderit laborum officia aute.",
-        description: `Id id excepteur minim elit enim elit ut mollit adipisicing sint ipsum magna. Labore dolor cillum velit ea ad reprehenderit eu excepteur non sit.`,
-        image:
-          "https://nexus.leagueoflegends.com/wp-content/uploads/2020/01/LOL_CMS_328_Tile_03_feature1-min_pg8w5yfionx3bdkekqvp.jpg",
-        commentsCount: 12,
-        category: "riot"
-      },
-      {
-        title: "Officia sunt duis aute esse anim dolore qui.",
-        description: `Quis laborum sit eiusmod duis in. Proident incididunt consequat laborum ut occaecat exercitation commodo aliquip cupidatat reprehenderit voluptate nisi incididunt tempor.`,
-        image:
-          "https://nexus.leagueoflegends.com/wp-content/uploads/2019/09/04_Pantheon-1_n77cg0g5px5wekv3mgwv.jpg",
-        commentsCount: 345,
-        category: "default"
+        title: post.title,
+        description: post.text,
+        image: post.imageUrl,
+        author: post.authors ? post.authors[0] : 'Riot Games',
+        category: 'riot',
+        tag: post.category,
+        link: `https://br.leagueoflegends.com/pt-br${post.link.url}`
       }
-    ];
+    ));
 
     return res.json(posts);
   }
@@ -110,4 +53,4 @@ class BankController {
   async destroy(req, res) {}
 }
 
-export default new BankController();
+export default new PostController();

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,9 +1,7 @@
-require("sucrase/register");
-
 import app from "./app";
 
-app.listen(process.env.NODE_PORT || 5000);
+app.listen(process.env.NODE_PORT || 5800);
 
-console.log(`Server started at port ${process.env.NODE_PORT || 5000}`);
+console.log(`Server started at port ${process.env.NODE_PORT || 5800}`);
 
 export default app;

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,7 +1,7 @@
 import app from "./app";
 
-app.listen(process.env.NODE_PORT || 5800);
+app.listen(process.env.NODE_PORT || 5000);
 
-console.log(`Server started at port ${process.env.NODE_PORT || 5800}`);
+console.log(`Server started at port ${process.env.NODE_PORT || 5000}`);
 
 export default app;

--- a/server/src/services/api/riot.js
+++ b/server/src/services/api/riot.js
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+class RiotApi {
+  page(page) {
+    return axios.create({
+      baseURL: `https://lolstatic-a.akamaihd.net/frontpage/apps/prod/harbinger-l10-website/pt-br/master/pt-br/page-data/${page}/page-data.json`
+    })
+  }
+}
+
+export default new RiotApi;

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -211,6 +211,13 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 axobject-query@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.2.tgz#ea187abe5b9002b377f925d8bf7d1c561adf38f9"
@@ -470,6 +477,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
@@ -939,6 +953,13 @@ flatted@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 forwarded@~0.1.2:
   version "0.1.2"


### PR DESCRIPTION
No windows o commando `HOST=0.0.0.0 react-scripts start` não funciona, pq no windows não da pra setar env var assim.

Instalei uma biblioteca que cuida disso e o comando ficou assim: 
`cross-env HOST=0.0.0.0 react-scripts start` 

Tem tbm nessa PR uma alteração no nodemon.json. Alterei o comando pro node cuidar das coisas usando o register do sucrase.