### PR TITLE
Nova url da api de novidades do site da riot

### DIFF
--- a/server/src/services/api/riot.js
+++ b/server/src/services/api/riot.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 class RiotApi {
   page(page) {
     return axios.create({
-      baseURL: `https://lolstatic-a.akamaihd.net/frontpage/apps/prod/harbinger-l10-website/pt-br/master/pt-br/page-data/${page}/page-data.json`
+      baseURL: `https://lolstatic-a.akamaihd.net/frontpage/apps/prod/harbinger-l10-website/pt-br/production/pt-br/page-data/${page}/page-data.json`
     })
   }
 }


### PR DESCRIPTION
A url da página de notícias mudou de

`https://lolstatic-a.akamaihd.net/frontpage/apps/prod/harbinger-l10-website/pt-br/`**master**`/pt-br/page-data/news/page-data.json`

para

`https://lolstatic-a.akamaihd.net/frontpage/apps/prod/harbinger-l10-website/pt-br/`**production**`/pt-br/page-data/news/page-data.json`